### PR TITLE
Improvements to expy_local_scan.c

### DIFF
--- a/README
+++ b/README
@@ -196,6 +196,26 @@ altered for Python)
                 exim.log('Rejected by Python', exim.LOG_REJECT)
                 exim.log("We're freaking out here!', exim.LOG_PANIC)
 
+        child_open(argv, envp, umask[, make_leader=False]):
+
+           Create a child process that runs the command specified.
+           "argv" and "envp" must be tuples of strings.
+
+           The return value is (stdout, stdin, pid), where stdout and stdin are
+           file descriptors to the appropriate pipes (stderr is joined with
+           stdout). The environment may be specified, and a new umask supplied.
+
+        child_open_exim(message[, sender="", sender_authentication=None])
+
+           Submit a new message to Exim, returning the PID of the subprocess.
+           Essentially, this is running 'exim -t -oem -oi -f sender -oMas auth'
+           (-oMas is omitted if no authentication is provided).
+
+        child_close(pid[, timeout=0])
+
+           Wait for a child process to terminate, or for a timeout (in seconds)
+           to expire. A timeout of zero (the default) means wait as long as it
+           takes. The return value is the process ending status.
 
     Constants
     ----------

--- a/README
+++ b/README
@@ -86,6 +86,14 @@ Exim 'configure' file, in the 'local_scan' section.
        Name of the function within your module that this
        software will try and execute to perform the local_scan.
 
+    expy_scan_failure
+
+       Type: string
+       Default: defer
+
+       Return code in case the local_scan functions fails. Possible values:
+       "accept", "defer", "deny".
+
 expy_path_add is probably the only one you'll really need. The others
 are handy if you don't care for their default values.
 

--- a/expy_local_scan.c
+++ b/expy_local_scan.c
@@ -293,7 +293,7 @@ static PyObject *expy_log_write(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "s|i", &str, &which))
         return NULL;
 
-    log_write(0, which, get_format_string(str, 0));
+    log_write(0, which, "%s", get_format_string(str, 0));
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -310,7 +310,7 @@ static PyObject *expy_debug_print(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "s", &str))
         return NULL;
 
-    debug_printf(get_format_string(str, 0));
+    debug_printf("%s", get_format_string(str, 0));
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -682,7 +682,7 @@ int local_scan(int fd, uschar **return_text)
                 {
                 *return_text = (uschar *)"Internal error";
                 log_write(0, LOG_PANIC, "Couldn't import Python 'sys' module");
-                log_write(0, LOG_PANIC, getPythonTraceback());
+                log_write(0, LOG_PANIC, "%s", getPythonTraceback());
                 return python_failure_return;
                 }
 
@@ -693,7 +693,7 @@ int local_scan(int fd, uschar **return_text)
                 {
                 *return_text = (uschar *)"Internal error";
                 log_write(0, LOG_PANIC, "expy: Python sys.path doesn't exist or isn't a list");
-                log_write(0, LOG_PANIC, getPythonTraceback());
+                log_write(0, LOG_PANIC, "%s", getPythonTraceback());
                 return python_failure_return;
                 }
 
@@ -795,7 +795,7 @@ int local_scan(int fd, uschar **return_text)
         {
         *return_text = (uschar *)"Internal error";
         log_write(0, LOG_PANIC, "local_scan function failed");
-        log_write(0, LOG_PANIC, getPythonTraceback());
+        log_write(0, LOG_PANIC, "%s", getPythonTraceback());
         Py_DECREF(original_recipients);
         clear_headers(header_tuple);
         Py_DECREF(header_tuple);

--- a/expy_local_scan.c
+++ b/expy_local_scan.c
@@ -652,6 +652,13 @@ int local_scan(int fd, uschar **return_text)
 
     if (!Py_IsInitialized())  /* local_scan() may have already been run */
         {
+        /* It is definitely cleanest to set a program name here. 
+        However, it's not really clear *what* name to use. In many ways,
+        Exim would be most accurate, but that will not necessarily be the
+        starting location for finding libraries that is wanted.
+        Hard-coding /usr/local/ here is SE specific, and something more
+        generic would need to be used to submit this upstream. */
+        Py_SetProgramName("/usr/local/bin/python");
         Py_Initialize();
         ExPy_Header_Line.ob_type = &PyType_Type;
         }


### PR DESCRIPTION
These changes include:
- Exposing child_open, child_open_exim2 and child_close in the exim module.
- Customizable local_scan failure return action.
- Silencing various compiler warnings.
